### PR TITLE
add a prebundled ESM version of SD, useful for importing helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn.lock
 
 # Native Builds
 build/
+format-helpers.esm.js
 
 # Android Specific Files
 .gradle/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ You can import the browser entrypoint:
 import StyleDictionary from 'browser-style-dictionary/browser.js';
 ```
 
+or if you want a prebundled ESM version of the format helpers:
+
+```js
+import StyleDictionary from 'browser-style-dictionary/format-helpers.esm.js';
+```
+
 ### Do yourself
 
 * Run Browserify or your own bundler of choice (e.g. [Rollup](https://rollupjs.org/)) to make this runnable in the browser. It is needed to replace Node exclusives with browser-compatible alternatives, like `fs`, `path`, `process`, etc.

--- a/format-helpers.js
+++ b/format-helpers.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/common/formatHelpers");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browser-style-dictionary",
-  "version": "3.0.2-browser.6",
+  "version": "3.0.2-browser.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "browser-style-dictionary",
-      "version": "3.0.2-browser.6",
+      "version": "3.0.2-browser.7",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -25,6 +25,8 @@
         "@babel/preset-env": "^7.10.2",
         "@commitlint/cli": "^11.0.0",
         "@commitlint/config-conventional": "^11.0.0",
+        "@rollup/plugin-commonjs": "^21.0.1",
+        "@rollup/plugin-json": "^4.1.0",
         "babel-jest": "^26.0.1",
         "babel-preset-env": "^1.7.0",
         "docsify": "^4.12.1",
@@ -40,6 +42,7 @@
         "less": "^3.11.2",
         "lint-staged": "^10.2.7",
         "node-sass": "^6.0.1",
+        "rollup": "^2.60.1",
         "standard-version": "^9.0.0",
         "stylus": "^0.54.8",
         "tsd": "^0.15.1",
@@ -2122,6 +2125,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
+      "integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.38.3"
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2201,6 +2260,12 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -4553,6 +4618,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -6485,6 +6556,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -8684,6 +8761,15 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -10426,6 +10512,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/make-dir": {
@@ -12880,6 +12975,21 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -13912,6 +14022,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "node_modules/spdx-correct": {
@@ -17854,6 +17970,49 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-commonjs": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
+      "integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -17927,6 +18086,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -19906,6 +20071,12 @@
       "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -21442,6 +21613,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
@@ -23128,6 +23305,15 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -24494,6 +24680,15 @@
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -26367,6 +26562,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.1.tgz",
+      "integrity": "sha512-akwfnpjY0rXEDSn1UTVfKXJhPsEBu+imi1gqBA1ZkHGydUnkV/fWCC90P7rDaLEW8KTwBcS1G3N4893Ndz+jwg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -27224,6 +27428,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-style-dictionary",
-  "version": "3.0.2-browser.6",
+  "version": "3.0.2-browser.7",
   "description": "Style once, use everywhere. A build system for creating cross-platform styles.",
   "keywords": [
     "style dictionary",
@@ -33,6 +33,7 @@
     "examples",
     "index.js",
     "browser.js",
+    "format-helpers.esm.js",
     "LICENSE",
     "NOTICE",
     "types"
@@ -131,6 +132,8 @@
     "@babel/preset-env": "^7.10.2",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-json": "^4.1.0",
     "babel-jest": "^26.0.1",
     "babel-preset-env": "^1.7.0",
     "docsify": "^4.12.1",
@@ -146,6 +149,7 @@
     "less": "^3.11.2",
     "lint-staged": "^10.2.7",
     "node-sass": "^6.0.1",
+    "rollup": "^2.60.1",
     "standard-version": "^9.0.0",
     "stylus": "^0.54.8",
     "tsd": "^0.15.1",

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,30 +1,42 @@
-const fs = require('fs');
-const path = require('path');
-const glob = require('glob');
+const fs = require("fs");
+const path = require("path");
+const glob = require("glob");
+const rollup = require("rollup");
+const commonjs = require("@rollup/plugin-commonjs");
+const json = require("@rollup/plugin-json");
 
-const allJSFiles = glob.sync('**/*.js', {
+const allJSFiles = glob.sync("**/*.js", {
   fs,
   ignore: [
-    'node_modules/**/*',
-    '__integration__/**/*',
-    '__tests__/**/*',
-    'examples/**/*'
-  ]
+    "node_modules/**/*",
+    "__integration__/**/*",
+    "__tests__/**/*",
+    "examples/**/*",
+  ],
 });
-allJSFiles.forEach(file => {
+allJSFiles.forEach((file) => {
   const filePath = path.resolve(file);
-  const fileData = fs.readFileSync(filePath, 'utf-8');
+  const fileData = fs.readFileSync(filePath, "utf-8");
   const replaced = fileData.replace(
     /fs.readFileSync\(\s*__dirname\s*\+\s*'\/templates\/(.*)'\)/g,
     (match, $1) => {
-      const tpl = path.join(
-        "./lib/common/templates",
-        $1
-      );
+      const tpl = path.join("./lib/common/templates", $1);
       return JSON.stringify(fs.readFileSync(tpl, "utf8"));
     }
   );
   if (replaced !== fileData) {
-    fs.writeFileSync(filePath, replaced, 'utf-8');
+    fs.writeFileSync(filePath, replaced, "utf-8");
   }
-})
+});
+
+(async () => {
+  const bundle = await rollup.rollup({
+    input: "format-helpers.js",
+    plugins: [json(), commonjs()],
+  });
+
+  const { output } = await bundle.generate({
+    format: "es",
+  });
+  fs.writeFileSync("format-helpers.esm.js", output[0].code, "utf-8");
+})();


### PR DESCRIPTION
Allows people to use prebundled ESM helpers, directly in the browser.

`config.js`
```js
import StyleDictionary from 'browser-style-dictionary/format-helpers-esm.js';

const { fileHeader, formattedVariables } = StyleDictionary.formatHelpers;

export default {
  ...sdConfig,
  format: {
    foo: ({dictionary, file, options}) => {
      const { outputReferences } = options;
      return `${fileHeader({file})}

:root {
  ${formattedVariables({format: 'css', dictionary, outputReferences})}
}
`;
  }
}
```

@gqio I don't think it makes much sense to prebundle all of style-dictionary browserified, because you'd still need to converge it in a single bundle in your app (backlight, playground, etc.) and have a single FS shim instance, but for these helpers it is quite nice to be able to just import them in the browser, they don't use any dependencies and don't rely on NodeJS internals or other singletons like a FS shim in memory etc.