### PR TITLE
handle inlining of type file in typescript/module-declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browser-style-dictionary",
-  "version": "3.1.1-browser.0",
+  "version": "3.1.1-browser.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "browser-style-dictionary",
-      "version": "3.1.1-browser.0",
+      "version": "3.1.1-browser.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-style-dictionary",
-  "version": "3.1.1-browser.1",
+  "version": "3.1.1-browser.2",
   "description": "Style once, use everywhere. A build system for creating cross-platform styles.",
   "keywords": [
     "style dictionary",

--- a/prepublish.js
+++ b/prepublish.js
@@ -18,12 +18,17 @@ allJSFiles.forEach((file) => {
   const filePath = path.resolve(file);
   const fileData = fs.readFileSync(filePath, "utf-8");
   const replaced = fileData.replace(
-    /fs.readFileSync\(\s*__dirname\s*\+\s*'\/templates\/(.*)'\)/g,
+    /fs\.readFileSync\(\s*__dirname\s*\+\s*'\/templates\/(.*)'\)/g,
     (match, $1) => {
       const tpl = path.join("./lib/common/templates", $1);
       return JSON.stringify(fs.readFileSync(tpl, "utf8"));
     }
-  );
+  ).replace(
+    /fs\.readFileSync\(\s*path\.resolve\(__dirname\s*\,\s*`\.\.\/\.\.\/types\/(.*)`\)\s*,\s*{\s*encoding:\s*'UTF-8'\s*}\s*\);/g,
+    (match, $1) => {
+      const tpl = path.join("./types", $1);
+      return JSON.stringify(fs.readFileSync(tpl, "utf8"));
+    });
   if (replaced !== fileData) {
     fs.writeFileSync(filePath, replaced, "utf-8");
   }


### PR DESCRIPTION
https://github.com/divriots/browser-style-dictionary/blob/main/lib/common/formats.js#L486

The above part of the code was not handled by our prepublish script which inlines the templates into the formats.js file.

See also the [style-dictionary-playground repro](https://www.style-dictionary-play.dev/#project=pVRNb4MwDP0rFbtVDLrb1uuk7rr76CFAStOSBDmhKqr478vHaEP4KNJyoODYz/Z7rm9BhiCP9SOS/IyZiE6Cs2Ab3BK2WiXmOgm2K/OpDSmHHINj0kZAOalFz6jNlKekxJ5ZX1xQWRt7Etx0LIkYZ7hNgodbG7pIORZnyatFUIL2gbrXv5cOOAmOWPmzwusl4yWHQStuGuMRHTiTUYqEW/YghcRX+R98iUESBM1IDv2jHm0QWshY1zIhopdSqah8vboKQM2grJIURznP+sunOdPaUayGgz4B+TBnZgAQnJ9AvJkzLn3ozCrO59h/2e026jh8hy5HGLPZ6M1Gxy9Qy8q7TC3t66k1EHB8iMxMqI7b8X4EzjhT1DZLoQwBE2DdrC7HQk2kdX023OxACo8jwWvIDOZPR9J6Ha9dQi3oPrQBVYnkgQMVPWJPwqNVAmJC+30Brytbs3Zy2kxrUubfSB7trfmMTyLuOR3U3hNOefp4o6tWmiQMScKZRbogIChVcVEvYzcCQJG0jrKpsMiAVDKmPK9L/JrjrERgsMToH2A/5NUsy5mlYe57bOkd7fHlSHsf+sf2E3Ta/b263gPuVbW/)