### PR TITLE
Update resolveObject.js

### DIFF
--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -85,16 +85,20 @@ function compile_value(value, stack) {
   // references can be part of the value such as "1px solid {color.border.light}"
   value.replace(regex, function(match, variable) {
     variable = variable.trim();
-    if (options.ignorePaths.indexOf(variable) !== -1) {
-      return value;
-    }
-
-    stack.push(variable);
 
     // Find what the value is referencing
     const pathName = getPath(variable, options);
     const context = getName(current_context, options);
     const refHasValue = pathName[pathName.length-1] === 'value';
+
+    if (refHasValue && options.ignorePaths.indexOf(variable) !== -1) {
+      return value;
+    } else if (!refHasValue && options.ignorePaths.indexOf(`${variable}.value`) !== -1) {
+      return value;
+    }
+
+    stack.push(variable);
+
     ref = resolveReference(pathName, updated_object);
 
     // If the reference doesn't end in 'value'
@@ -108,7 +112,7 @@ function compile_value(value, stack) {
     }
 
     if (typeof ref !== 'undefined') {
-      if (typeof ref === 'string') {
+      if (typeof ref === 'string' || typeof ref === 'number') {
         to_ret = value.replace(match, ref);
 
         // Recursive, therefore we can compute multi-layer variables like a = b, b = c, eventually a = c
@@ -145,8 +149,12 @@ function compile_value(value, stack) {
             to_ret = compile_value( to_ret, stack );
           }
         }
+        // if evaluated value is a number and equal to the reference, we want to keep the type
+        if (typeof ref === 'number' && ref.toString() === to_ret) {
+          to_ret = ref;
+        }
       } else {
-        // if evaluated value is not a string, we want to keep the type
+        // if evaluated value is not a string or number, we want to keep the type
         to_ret = ref;
       }
     } else {


### PR DESCRIPTION
Fixes string references in token values to not be evaluated

*Issue #, if available:*
When given some string values, the strings would evaluate rather than be ignored. This fix was transplanted from the main repo.

*Description of changes:*
Ex:
`value: {Spacing Base Unit} * {Spatial Multiplier}`
Expected:
`value: {Spacing Base Unit} * {Spatial Multiplier}`
Actual:
`value: 1.25`

*References*
https://github.com/amzn/style-dictionary/pull/808
https://github.com/amzn/style-dictionary/pull/825

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
